### PR TITLE
Always also fly upward if you jump

### DIFF
--- a/characters/wizard/wizard.gd
+++ b/characters/wizard/wizard.gd
@@ -82,9 +82,10 @@ func _physics_process(delta):
 		Input.is_action_pressed("move_right")
 
 	var using_jetpack = is_strafing or is_jumping
+	var strafing_and_jumping_penalty = 0.4
 
 	if using_jetpack and can_use_jetpack():
-		var strafe_speed = JETPACK_STRAFE_SPEED if not is_jumping else JETPACK_STRAFE_SPEED / 2
+		var strafe_speed = JETPACK_STRAFE_SPEED if not is_jumping else JETPACK_STRAFE_SPEED * strafing_and_jumping_penalty
 		if Input.is_action_pressed("move_left"):
 			velocity.x -= strafe_speed
 		elif Input.is_action_pressed("move_right"):
@@ -100,7 +101,10 @@ func _physics_process(delta):
 		jetpack_exhaust.emitting = false
 
 	if using_jetpack:
-		deplete_jetpack(delta)
+		var depletion = delta
+		if is_jumping and is_strafing:
+			depletion *= 1+ strafing_and_jumping_penalty
+		deplete_jetpack(depletion)
 	else:
 		charge_jetpack(delta)
 

--- a/characters/wizard/wizard.gd
+++ b/characters/wizard/wizard.gd
@@ -77,16 +77,20 @@ func _physics_process(delta):
 	if is_petrified:
 		return
 
-	var using_jetpack = Input.is_action_pressed("move_left") or\
-		Input.is_action_pressed("move_right") or\
-		Input.is_action_pressed("jump")
+	var is_jumping = Input.is_action_pressed("jump")
+	var is_strafing = Input.is_action_pressed("move_left") or\
+		Input.is_action_pressed("move_right")
+
+	var using_jetpack = is_strafing or is_jumping
 
 	if using_jetpack and can_use_jetpack():
+		var strafe_speed = JETPACK_STRAFE_SPEED if not is_jumping else JETPACK_STRAFE_SPEED / 2
 		if Input.is_action_pressed("move_left"):
-			velocity.x -= JETPACK_STRAFE_SPEED
+			velocity.x -= strafe_speed
 		elif Input.is_action_pressed("move_right"):
-			velocity.x += JETPACK_STRAFE_SPEED
-		else:
+			velocity.x += strafe_speed
+
+		if is_jumping:
 			velocity.y -= JETPACK_SPEED * FLOOR_BOOST_FACTOR if is_on_floor else JETPACK_SPEED
 
 		apply_drag(delta)


### PR DESCRIPTION
So, at first I was super confused because the guy just didn't fly upwards, even when pressing *jump*!
Turns out moving left and right had precedence and completely cancelled flying upwards. I think flying upwards should have precedence.

Also, I thought it might be fun to allow a bit of control when flying upwards, that's why I also allowed the `JETPACK_STRAFE_SPEED` to have a bit of an influence.  You guys know the game better than me, of course, so we can also adjust / remove the influence.